### PR TITLE
reconnect port leak

### DIFF
--- a/src/eredis.appup.src
+++ b/src/eredis.appup.src
@@ -1,5 +1,5 @@
 %% -*- mode: erlang -*-
-{"1.2.7",
+{"1.2.8",
   [
     {"1.1.0", [
       {load_module, eredis_client, brutal_purge, soft_purge, []},
@@ -87,6 +87,9 @@
       {load_module, eredis_client, brutal_purge, soft_purge, []}
     ]},
     {"1.2.6", [
+     {load_module, eredis_client, brutal_purge, soft_purge, []}
+    ]},
+    {"1.2.7", [
       {load_module, eredis_client, brutal_purge, soft_purge, []}
     ]}
   ]

--- a/src/eredis.appup.src
+++ b/src/eredis.appup.src
@@ -43,6 +43,9 @@
     ]},
     {"1.2.6", [
       {load_module, eredis_client, brutal_purge, soft_purge, []}
+    ]},
+     {"1.2.7", [
+      {load_module, eredis_client, brutal_purge, soft_purge, []}
     ]}
   ],
   [

--- a/src/eredis_client.erl
+++ b/src/eredis_client.erl
@@ -496,13 +496,13 @@ reconnect_loop(Client, #state{reconnect_sleep = ReconnectSleep} = State, Options
             [Client ! M || M <- Msgs];
         {error, _Reason} ->
             timer:sleep(ReconnectSleep),
-            reconnect_loop(Client, State, Options);
+            ?MODULE:reconnect_loop(Client, State, Options);
         %% Something bad happened when connecting, like Redis might be
         %% loading the dataset and we got something other than 'OK' in
         %% auth or select
         _ ->
             timer:sleep(ReconnectSleep),
-            reconnect_loop(Client, State, Options)
+            ?MODULE:reconnect_loop(Client, State, Options)
     end.
 
 read_database(undefined) ->


### PR DESCRIPTION
1. The created socket is not released when authenticating fails (the password is not correct).
2. `options` are not valid on the reconnect_loop process.
3. link `reconnect_loop process` to monitor its abnormal exit. Ensure that the reconnected process can exit normally when the main process exits.