### PR TITLE
fix: hide password

### DIFF
--- a/include/eredis.hrl
+++ b/include/eredis.hrl
@@ -2,7 +2,8 @@
 
 -type reconnect_sleep() :: no_reconnect | integer().
 
--type option() :: {host, string()} | {port, integer()} | {database, string()} | {password, string()} | {reconnect_sleep, reconnect_sleep()}.
+-type password() :: binary() | string() | function().
+-type option() :: {host, string()} | {port, integer()} | {database, string()} | {password, password()} | {reconnect_sleep, reconnect_sleep()}.
 -type server_args() :: [option()].
 
 -type return_value() :: undefined | binary() | [binary() | nonempty_list()].

--- a/include/eredis_sub.hrl
+++ b/include/eredis_sub.hrl
@@ -2,7 +2,7 @@
 -record(state, {
           host :: string() | undefined,
           port :: integer() | undefined,
-          password :: binary() | undefined,
+          password :: password() | undefined,
           reconnect_sleep :: integer() | undefined | no_reconnect,
 
           socket :: port() | undefined,

--- a/src/eredis.appup.src
+++ b/src/eredis.appup.src
@@ -1,5 +1,5 @@
 %% -*- mode: erlang -*-
-{"1.2.8",
+{"1.2.9",
   [
     {"1.1.0", [
       {load_module, eredis_client, brutal_purge, soft_purge, []},
@@ -7,45 +7,63 @@
       {load_module, eredis_parser, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel_client, brutal_purge, soft_purge, []},
-      {load_module, eredis_sentinel_sup, brutal_purge, soft_purge, []}
+      {load_module, eredis_sentinel_sup, brutal_purge, soft_purge, []},
+      {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]},
     {"1.2.0", [
       {load_module, eredis, brutal_purge, soft_purge, []},
       {load_module, eredis_client, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel_client, brutal_purge, soft_purge, []},
-      {load_module, eredis_sentinel_sup, brutal_purge, soft_purge, []}
+      {load_module, eredis_sentinel_sup, brutal_purge, soft_purge, []},
+      {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]},
     {"1.2.1", [
       {load_module, eredis, brutal_purge, soft_purge, []},
       {load_module, eredis_client, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel_client, brutal_purge, soft_purge, []},
-      {load_module, eredis_sentinel_sup, brutal_purge, soft_purge, []}
+      {load_module, eredis_sentinel_sup, brutal_purge, soft_purge, []},
+      {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]},
     {"1.2.2", [
       {load_module, eredis, brutal_purge, soft_purge, []},
       {load_module, eredis_client, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel_client, brutal_purge, soft_purge, []},
-      {load_module, eredis_sentinel_sup, brutal_purge, soft_purge, []}
+      {load_module, eredis_sentinel_sup, brutal_purge, soft_purge, []},
+      {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]},
     {"1.2.3", [
       {load_module, eredis, brutal_purge, soft_purge, []},
-      {load_module, eredis_client, brutal_purge, soft_purge, []}
+      {load_module, eredis_client, brutal_purge, soft_purge, []},
+      {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]},
     {"1.2.4", [
       {load_module, eredis, brutal_purge, soft_purge, []},
-      {load_module, eredis_client, brutal_purge, soft_purge, []}
+      {load_module, eredis_client, brutal_purge, soft_purge, []},
+      {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]},
     {"1.2.5", [
-      {load_module, eredis_client, brutal_purge, soft_purge, []}
+      {load_module, eredis, brutal_purge, soft_purge, []},
+      {load_module, eredis_client, brutal_purge, soft_purge, []},
+      {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]},
     {"1.2.6", [
-      {load_module, eredis_client, brutal_purge, soft_purge, []}
+      {load_module, eredis, brutal_purge, soft_purge, []},
+      {load_module, eredis_client, brutal_purge, soft_purge, []},
+      {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]},
      {"1.2.7", [
-      {load_module, eredis_client, brutal_purge, soft_purge, []}
+      {load_module, eredis, brutal_purge, soft_purge, []},
+      {load_module, eredis_client, brutal_purge, soft_purge, []},
+      {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
+    ]},
+     {"1.2.8", [
+      {add_module, eredis_secret},
+      {load_module, eredis, brutal_purge, soft_purge, []},
+      {load_module, eredis_client, brutal_purge, soft_purge, []},
+      {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]}
   ],
   [
@@ -55,45 +73,64 @@
       {load_module, eredis_parser, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel_client, brutal_purge, soft_purge, []},
-      {load_module, eredis_sentinel_sup, brutal_purge, soft_purge, []}
+      {load_module, eredis_sentinel_sup, brutal_purge, soft_purge, []},
+      {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]},
     {"1.2.0", [
       {load_module, eredis, brutal_purge, soft_purge, []},
       {load_module, eredis_client, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel_client, brutal_purge, soft_purge, []},
-      {load_module, eredis_sentinel_sup, brutal_purge, soft_purge, []}
+      {load_module, eredis_sentinel_sup, brutal_purge, soft_purge, []},
+      {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]},
     {"1.2.1", [
       {load_module, eredis, brutal_purge, soft_purge, []},
       {load_module, eredis_client, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel_client, brutal_purge, soft_purge, []},
-      {load_module, eredis_sentinel_sup, brutal_purge, soft_purge, []}
+      {load_module, eredis_sentinel_sup, brutal_purge, soft_purge, []},
+      {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]},
     {"1.2.2", [
       {load_module, eredis, brutal_purge, soft_purge, []},
       {load_module, eredis_client, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel_client, brutal_purge, soft_purge, []},
-      {load_module, eredis_sentinel_sup, brutal_purge, soft_purge, []}
+      {load_module, eredis_sentinel_sup, brutal_purge, soft_purge, []},
+      {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]},
     {"1.2.3", [
       {load_module, eredis, brutal_purge, soft_purge, []},
-      {load_module, eredis_client, brutal_purge, soft_purge, []}
+      {load_module, eredis_client, brutal_purge, soft_purge, []},
+      {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]},
     {"1.2.4", [
       {load_module, eredis, brutal_purge, soft_purge, []},
-      {load_module, eredis_client, brutal_purge, soft_purge, []}
+      {load_module, eredis_client, brutal_purge, soft_purge, []},
+      {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]},
     {"1.2.5", [
-      {load_module, eredis_client, brutal_purge, soft_purge, []}
+      {load_module, eredis, brutal_purge, soft_purge, []},
+      {load_module, eredis_client, brutal_purge, soft_purge, []},
+      {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]},
     {"1.2.6", [
-     {load_module, eredis_client, brutal_purge, soft_purge, []}
+     {load_module, eredis, brutal_purge, soft_purge, []},
+     {load_module, eredis_client, brutal_purge, soft_purge, []},
+     {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]},
     {"1.2.7", [
-      {load_module, eredis_client, brutal_purge, soft_purge, []}
-    ]}
+      {load_module, eredis_client, brutal_purge, soft_purge, []},
+      {load_module, eredis, brutal_purge, soft_purge, []},
+      {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
+    ]},
+    {"1.2.8", [
+     % {delete_module, eredis_secret}, %% this is intended to be commented out,
+     % because we can not downgrade (unwrap) the already wrapped passwords
+     {load_module, eredis, brutal_purge, soft_purge, []},
+     {load_module, eredis_client, brutal_purge, soft_purge, []},
+     {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
+   ]}
   ]
 }.

--- a/src/eredis.erl
+++ b/src/eredis.erl
@@ -53,7 +53,7 @@ start_link(Host, Port, Database, Password, ReconnectSleep, ConnectTimeout, Optio
   when is_list(Host),
        is_integer(Port),
        is_integer(Database) orelse Database == undefined,
-       is_list(Password) orelse is_binary(Password),
+       (is_list(Password) orelse is_binary(Password) orelse is_function(Password, 0)),
        is_integer(ReconnectSleep) orelse ReconnectSleep =:= no_reconnect,
        is_integer(ConnectTimeout) ->
 
@@ -64,7 +64,7 @@ start_link(Host, Port, Database, Password, ReconnectSleep, ConnectTimeout, Optio
 -spec start_link(server_args()) -> {ok, Pid::pid()} | {error, Reason::term()}.
 start_link(Args) ->
     Database       = proplists:get_value(database, Args, 0),
-    Password       = proplists:get_value(password, Args, ""),
+    Password       = eredis_secret:wrap(proplists:get_value(password, Args, "")),
     ReconnectSleep = proplists:get_value(reconnect_sleep, Args, 100),
     ConnectTimeout = proplists:get_value(connect_timeout, Args, ?TIMEOUT),
     Options = proplists:get_value(options, Args, []),

--- a/src/eredis_secret.erl
+++ b/src/eredis_secret.erl
@@ -1,0 +1,24 @@
+%% Note: this module CAN'T be hot-patched to avoid invalidating the
+%% closures, so it must not be changed.
+-module(eredis_secret).
+
+%% API:
+-export([wrap/1, unwrap/1]).
+
+%%================================================================================
+%% API funcions
+%%================================================================================
+
+wrap(undefined) -> undefined;
+wrap(Func) when is_function(Func, 0) ->
+    Func;
+wrap(Term) ->
+    fun() ->
+        Term
+    end.
+
+unwrap(Term) when is_function(Term, 0) ->
+    %% Handle potentially nested funs
+    unwrap(Term());
+unwrap(Term) ->
+    Term.


### PR DESCRIPTION
This PR is to make eredis' `start_link` functions accept anonymous function in the args for password.
It also tries to wrap plaintext passwords in an anonymous function to avoid future changes to log arguments or states to logs.