### PR TITLE
chore: improve error messages when connect failed

### DIFF
--- a/include/eredis.hrl
+++ b/include/eredis.hrl
@@ -2,7 +2,8 @@
 
 -type reconnect_sleep() :: no_reconnect | integer().
 
--type option() :: {host, string()} | {port, integer()} | {database, string()} | {password, string()} | {reconnect_sleep, reconnect_sleep()}.
+-type password() :: binary() | string() | function().
+-type option() :: {host, string()} | {port, integer()} | {database, string()} | {password, password()} | {reconnect_sleep, reconnect_sleep()}.
 -type server_args() :: [option()].
 
 -type return_value() :: undefined | binary() | [binary() | nonempty_list()].

--- a/include/eredis_sub.hrl
+++ b/include/eredis_sub.hrl
@@ -2,7 +2,7 @@
 -record(state, {
           host :: string() | undefined,
           port :: integer() | undefined,
-          password :: binary() | undefined,
+          password :: password() | undefined,
           reconnect_sleep :: integer() | undefined | no_reconnect,
 
           socket :: port() | undefined,

--- a/src/eredis.appup.src
+++ b/src/eredis.appup.src
@@ -1,5 +1,5 @@
 %% -*- mode: erlang -*-
-{"1.2.8",
+{"1.2.9",
   [
     {"1.1.0", [
       {load_module, eredis_client, brutal_purge, soft_purge, []},
@@ -38,13 +38,7 @@
       {load_module, eredis, brutal_purge, soft_purge, []},
       {load_module, eredis_client, brutal_purge, soft_purge, []}
     ]},
-    {"1.2.5", [
-      {load_module, eredis_client, brutal_purge, soft_purge, []}
-    ]},
-    {"1.2.6", [
-      {load_module, eredis_client, brutal_purge, soft_purge, []}
-    ]},
-     {"1.2.7", [
+    {<<"1.2.[5-7]">>, [
       {load_module, eredis_client, brutal_purge, soft_purge, []}
     ]}
   ],
@@ -86,13 +80,7 @@
       {load_module, eredis, brutal_purge, soft_purge, []},
       {load_module, eredis_client, brutal_purge, soft_purge, []}
     ]},
-    {"1.2.5", [
-      {load_module, eredis_client, brutal_purge, soft_purge, []}
-    ]},
-    {"1.2.6", [
-     {load_module, eredis_client, brutal_purge, soft_purge, []}
-    ]},
-    {"1.2.7", [
+    {<<"1.2.[5-7]">>, [
       {load_module, eredis_client, brutal_purge, soft_purge, []}
     ]}
   ]

--- a/src/eredis.appup.src
+++ b/src/eredis.appup.src
@@ -2,6 +2,7 @@
 {"1.2.9",
   [
     {"1.1.0", [
+      {add_module, eredis_secret},
       {load_module, eredis_client, brutal_purge, soft_purge, []},
       {load_module, eredis, brutal_purge, soft_purge, [eredis_client]},
       {load_module, eredis_parser, brutal_purge, soft_purge, []},
@@ -11,47 +12,55 @@
       {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]},
     {"1.2.0", [
+      {add_module, eredis_secret},
       {load_module, eredis, brutal_purge, soft_purge, []},
-      {load_module, eredis_client, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel_client, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel_sup, brutal_purge, soft_purge, []},
+      {load_module, eredis_client, brutal_purge, soft_purge, []},
       {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]},
     {"1.2.1", [
+      {add_module, eredis_secret},
       {load_module, eredis, brutal_purge, soft_purge, []},
-      {load_module, eredis_client, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel_client, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel_sup, brutal_purge, soft_purge, []},
+      {load_module, eredis_client, brutal_purge, soft_purge, []},
       {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]},
     {"1.2.2", [
+      {add_module, eredis_secret},
       {load_module, eredis, brutal_purge, soft_purge, []},
-      {load_module, eredis_client, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel_client, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel_sup, brutal_purge, soft_purge, []},
+      {load_module, eredis_client, brutal_purge, soft_purge, []},
       {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]},
     {"1.2.3", [
+      {add_module, eredis_secret},
       {load_module, eredis, brutal_purge, soft_purge, []},
       {load_module, eredis_client, brutal_purge, soft_purge, []},
       {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]},
     {"1.2.4", [
+      {add_module, eredis_secret},
       {load_module, eredis, brutal_purge, soft_purge, []},
       {load_module, eredis_client, brutal_purge, soft_purge, []},
       {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]},
     {<<"1\\.2\\.[5-8]">>, [
+      {add_module, eredis_secret},
       {load_module, eredis_client, brutal_purge, soft_purge, []},
       {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]}
   ],
+  % {delete_module, eredis_secret}, %% this is intended to be missing in downgrade instructions,
+  % because this module should never change anyway
   [
     {"1.1.0",[
-      {load_module, eredis_client,  brutal_purge, soft_purge, []},
+      {load_module, eredis_client, brutal_purge, soft_purge, []},
       {load_module, eredis, brutal_purge, soft_purge, [eredis_client]},
       {load_module, eredis_parser, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel, brutal_purge, soft_purge, []},
@@ -61,26 +70,26 @@
     ]},
     {"1.2.0", [
       {load_module, eredis, brutal_purge, soft_purge, []},
-      {load_module, eredis_client, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel_client, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel_sup, brutal_purge, soft_purge, []},
+      {load_module, eredis_client, brutal_purge, soft_purge, []},
       {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]},
     {"1.2.1", [
       {load_module, eredis, brutal_purge, soft_purge, []},
-      {load_module, eredis_client, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel_client, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel_sup, brutal_purge, soft_purge, []},
+      {load_module, eredis_client, brutal_purge, soft_purge, []},
       {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]},
     {"1.2.2", [
       {load_module, eredis, brutal_purge, soft_purge, []},
-      {load_module, eredis_client, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel_client, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel_sup, brutal_purge, soft_purge, []},
+      {load_module, eredis_client, brutal_purge, soft_purge, []},
       {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]},
     {"1.2.3", [

--- a/src/eredis.appup.src
+++ b/src/eredis.appup.src
@@ -7,39 +7,46 @@
       {load_module, eredis_parser, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel_client, brutal_purge, soft_purge, []},
-      {load_module, eredis_sentinel_sup, brutal_purge, soft_purge, []}
+      {load_module, eredis_sentinel_sup, brutal_purge, soft_purge, []},
+      {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]},
     {"1.2.0", [
       {load_module, eredis, brutal_purge, soft_purge, []},
       {load_module, eredis_client, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel_client, brutal_purge, soft_purge, []},
-      {load_module, eredis_sentinel_sup, brutal_purge, soft_purge, []}
+      {load_module, eredis_sentinel_sup, brutal_purge, soft_purge, []},
+      {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]},
     {"1.2.1", [
       {load_module, eredis, brutal_purge, soft_purge, []},
       {load_module, eredis_client, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel_client, brutal_purge, soft_purge, []},
-      {load_module, eredis_sentinel_sup, brutal_purge, soft_purge, []}
+      {load_module, eredis_sentinel_sup, brutal_purge, soft_purge, []},
+      {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]},
     {"1.2.2", [
       {load_module, eredis, brutal_purge, soft_purge, []},
       {load_module, eredis_client, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel_client, brutal_purge, soft_purge, []},
-      {load_module, eredis_sentinel_sup, brutal_purge, soft_purge, []}
+      {load_module, eredis_sentinel_sup, brutal_purge, soft_purge, []},
+      {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]},
     {"1.2.3", [
       {load_module, eredis, brutal_purge, soft_purge, []},
-      {load_module, eredis_client, brutal_purge, soft_purge, []}
+      {load_module, eredis_client, brutal_purge, soft_purge, []},
+      {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]},
     {"1.2.4", [
       {load_module, eredis, brutal_purge, soft_purge, []},
-      {load_module, eredis_client, brutal_purge, soft_purge, []}
+      {load_module, eredis_client, brutal_purge, soft_purge, []},
+      {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]},
-    {<<"1.2.[5-7]">>, [
-      {load_module, eredis_client, brutal_purge, soft_purge, []}
+    {<<"1\\.2\\.[5-8]">>, [
+      {load_module, eredis_client, brutal_purge, soft_purge, []},
+      {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]}
   ],
   [
@@ -49,39 +56,46 @@
       {load_module, eredis_parser, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel_client, brutal_purge, soft_purge, []},
-      {load_module, eredis_sentinel_sup, brutal_purge, soft_purge, []}
+      {load_module, eredis_sentinel_sup, brutal_purge, soft_purge, []},
+      {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]},
     {"1.2.0", [
       {load_module, eredis, brutal_purge, soft_purge, []},
       {load_module, eredis_client, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel_client, brutal_purge, soft_purge, []},
-      {load_module, eredis_sentinel_sup, brutal_purge, soft_purge, []}
+      {load_module, eredis_sentinel_sup, brutal_purge, soft_purge, []},
+      {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]},
     {"1.2.1", [
       {load_module, eredis, brutal_purge, soft_purge, []},
       {load_module, eredis_client, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel_client, brutal_purge, soft_purge, []},
-      {load_module, eredis_sentinel_sup, brutal_purge, soft_purge, []}
+      {load_module, eredis_sentinel_sup, brutal_purge, soft_purge, []},
+      {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]},
     {"1.2.2", [
       {load_module, eredis, brutal_purge, soft_purge, []},
       {load_module, eredis_client, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel, brutal_purge, soft_purge, []},
       {load_module, eredis_sentinel_client, brutal_purge, soft_purge, []},
-      {load_module, eredis_sentinel_sup, brutal_purge, soft_purge, []}
+      {load_module, eredis_sentinel_sup, brutal_purge, soft_purge, []},
+      {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]},
     {"1.2.3", [
       {load_module, eredis, brutal_purge, soft_purge, []},
-      {load_module, eredis_client, brutal_purge, soft_purge, []}
+      {load_module, eredis_client, brutal_purge, soft_purge, []},
+      {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]},
     {"1.2.4", [
       {load_module, eredis, brutal_purge, soft_purge, []},
-      {load_module, eredis_client, brutal_purge, soft_purge, []}
+      {load_module, eredis_client, brutal_purge, soft_purge, []},
+      {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]},
-    {<<"1.2.[5-7]">>, [
-      {load_module, eredis_client, brutal_purge, soft_purge, []}
+    {<<"1\\.2\\.[5-8]">>, [
+      {load_module, eredis_client, brutal_purge, soft_purge, []},
+      {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]}
   ]
 }.

--- a/src/eredis.erl
+++ b/src/eredis.erl
@@ -53,7 +53,7 @@ start_link(Host, Port, Database, Password, ReconnectSleep, ConnectTimeout, Optio
   when is_list(Host),
        is_integer(Port),
        is_integer(Database) orelse Database == undefined,
-       is_list(Password) orelse is_binary(Password),
+       (is_list(Password) orelse is_binary(Password) orelse is_function(Password, 0)),
        is_integer(ReconnectSleep) orelse ReconnectSleep =:= no_reconnect,
        is_integer(ConnectTimeout) ->
 

--- a/src/eredis_client.erl
+++ b/src/eredis_client.erl
@@ -30,7 +30,7 @@
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
-         terminate/2, code_change/3]).
+         terminate/2, code_change/3, format_status/2]).
 
 -export([reconnect_loop/3]).
 
@@ -226,6 +226,11 @@ terminate(_Reason, State) ->
 %% Down
 code_change(_, State, _) ->
     {ok, State}.
+
+format_status(_Opt, [_PDict, #state{} = State]) ->
+    [{data, [{"State", State#state{password = "******"}}]}];
+format_status(_Opt, [_PDict, State]) ->
+    [{data, [{"State", State}]}].
 
 close(_Transport, undefined) -> ok;
 close(Transport, Socket) ->

--- a/src/eredis_client.erl
+++ b/src/eredis_client.erl
@@ -37,7 +37,7 @@
 -record(state, {
           host :: string() | undefined,
           port :: integer() | undefined,
-          password :: binary() | undefined,
+          password :: password() | undefined,
           database :: binary() | undefined,
           sentinel :: undefined | atom(),
           reconnect_sleep :: reconnect_sleep() | undefined,
@@ -55,7 +55,7 @@
                  Host::list(),
                  Port::integer(),
                  Database::integer() | undefined,
-                 Password::string() | binary() | undefined,
+                 Password::password() | undefined,
                  ReconnectSleep::reconnect_sleep(),
                  ConnectTimeout::integer() | undefined,
                  Options::list()
@@ -67,7 +67,7 @@ start_link(Host, Port, Database, Password, ReconnectSleep, ConnectTimeout, Optio
                  Host::list(),
                  Port::integer(),
                  Database::integer() | binary() | undefined,
-                 Password::string(),
+                 Password::password(),
                  ReconnectSleep::reconnect_sleep(),
                  ConnectTimeout::integer() | undefined
                 ) -> {ok, Pid::pid()} | {error, Reason::term()}.
@@ -91,7 +91,8 @@ init([Host, Port, Database, Password, ReconnectSleep, ConnectTimeout, Options]) 
     State = #state{host = Host,
                    port = Port,
                    database = read_database(Database),
-                   password = l2b(Password),
+                   %% cannot keep password wrapped, because otherwise troulbe after downgrade
+                   password = eredis_secret:unwrap(Password),
                    reconnect_sleep = ReconnectSleep,
                    connect_timeout = ConnectTimeout,
                    parser_state = eredis_parser:init(),
@@ -223,7 +224,6 @@ handle_info(_Info, State) ->
 terminate(_Reason, State) ->
     close(State#state.socket).
 
-%% Down
 code_change(_, State, _) ->
     {ok, State}.
 
@@ -423,7 +423,7 @@ get_tcp_options(_State, Options) ->
     end.
 
 handle_connect(State, {ok, Transport, Socket}) ->
-    case authenticate(Socket, State#state.password) of
+    case authenticate(Socket, get_password(State)) of
         ok ->
             case select_database(Socket, State#state.database) of
                 ok ->
@@ -576,5 +576,8 @@ get_tranport() ->
         Transport -> Transport
     end.
 
-l2b(L) when is_list(L) -> list_to_binary(L);
+l2b(L) when is_list(L) -> iolist_to_binary(L);
 l2b(B) -> B.
+
+get_password(#state{password = Password}) ->
+    l2b(eredis_secret:unwrap(Password)).

--- a/src/eredis_secret.erl
+++ b/src/eredis_secret.erl
@@ -1,0 +1,24 @@
+%% Note: this module CAN'T be hot-patched to avoid invalidating the
+%% closures, so it must not be changed.
+-module(eredis_secret).
+
+%% API:
+-export([wrap/1, unwrap/1]).
+
+%%================================================================================
+%% API funcions
+%%================================================================================
+
+wrap(undefined) -> undefined;
+wrap(Func) when is_function(Func, 0) ->
+    Func;
+wrap(Term) ->
+    fun() ->
+        Term
+    end.
+
+unwrap(Term) when is_function(Term, 0) ->
+    %% Handle potentially nested funs
+    unwrap(Term());
+unwrap(Term) ->
+    Term.

--- a/src/eredis_sub_client.erl
+++ b/src/eredis_sub_client.erl
@@ -18,7 +18,7 @@
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
-         terminate/2, code_change/3]).
+         terminate/2, code_change/3, format_status/2]).
 
 %%
 %% API
@@ -235,6 +235,12 @@ terminate(_Reason, State) ->
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
+
+
+format_status(_Opt, [_PDict, #state{} = State]) ->
+    [{data, [{"State", State#state{password = "******"}}]}];
+format_status(_Opt, [_PDict, State]) ->
+    [{data, [{"State", State}]}].
 
 %%--------------------------------------------------------------------
 %%% Internal functions

--- a/src/eredis_sub_client.erl
+++ b/src/eredis_sub_client.erl
@@ -26,7 +26,7 @@
 
 -spec start_link(Host::list(),
                  Port::integer(),
-                 Password::string(),
+                 Password::password(),
                  Database::integer(),
                  ReconnectSleep::reconnect_sleep(),
                  MaxQueueSize::integer() | infinity,
@@ -51,7 +51,8 @@ init([Host, Port, Password, Database, ReconnectSleep, MaxQueueSize, QueueBehavio
     end,
     State = #state{host            = Host,
                    port            = Port,
-                   password        = list_to_binary(Password),
+                   %% cannot keep password wrapped, because otherwise troulbe after downgrade
+                   password        = eredis_secret:unwrap(Password),
                    reconnect_sleep = ReconnectSleep,
                    channels        = [],
                    parser_state    = eredis_parser:init(),
@@ -233,9 +234,8 @@ terminate(_Reason, State) ->
     end,
     ok.
 
-code_change(_OldVsn, State, _Extra) ->
+code_change(_, State, _) ->
     {ok, State}.
-
 
 format_status(_Opt, [_PDict, #state{} = State]) ->
     [{data, [{"State", State#state{password = "******"}}]}];
@@ -340,7 +340,7 @@ connect1(State) ->
     case gen_tcp:connect(Addr, State#state.port,
                          [AFamily | ?SOCKET_OPTS], State#state.connect_timeout) of
         {ok, Socket} ->
-            case authenticate(Socket, State#state.password) of
+            case authenticate(Socket, get_password(State)) of
                 ok ->
                     case select_database(Socket, State#state.database) of
                         ok ->
@@ -445,3 +445,9 @@ read_database(undefined) ->
     undefined;
 read_database(Database) when is_integer(Database) ->
     list_to_binary(integer_to_list(Database)).
+
+l2b(L) when is_list(L) -> iolist_to_binary(L);
+l2b(B) -> B.
+
+get_password(#state{password = Password}) ->
+    l2b(eredis_secret:unwrap(Password)).


### PR DESCRIPTION
## before:
```
(emqx@127.0.0.1)10> rp(sys:get_status(hd(L))).
{status,<0.2926.0>,
        {module,gen_server},
        [[{'$ancestors',[<0.2925.0>,<0.2924.0>,'172.100.239.2#7000',
                         eredis_cluster_pool,eredis_cluster_sup,<0.2623.0>]},
          {options,[]},
          {transport,gen_tcp},
          {'$initial_call',{eredis_client,init,1}}],
         running,<0.2925.0>,[],
         [{header,"Status for generic server <0.2926.0>"},
          {data,[{"Status",running},
                 {"Parent",<0.2925.0>},
                 {"Logged events",[]}]},
          {data,[{"State",
                  #state{host = "172.100.239.2",port = 7000,
                         password = <<"public">>,database = <<"0">>,
                         sentinel = undefined,reconnect_sleep = no_reconnect,
                         connect_timeout = 5000,socket = #Port<0.80>,
                         parser_state = #pstate{state = undefined,
                                                continuation_data = undefined},
                         queue = {[],[]}}}]}]]}
ok
```
## after
```
(emqx@127.0.0.1)11> rp(sys:get_status(hd(L))).
{status,<0.2926.0>,
        {module,gen_server},
        [[{'$ancestors',[<0.2925.0>,<0.2924.0>,'172.100.239.2#7000',
                         eredis_cluster_pool,eredis_cluster_sup,<0.2623.0>]},
          {options,[]},
          {transport,gen_tcp},
          {'$initial_call',{eredis_client,init,1}}],
         running,<0.2925.0>,[],
         [{header,"Status for generic server <0.2926.0>"},
          {data,[{"Status",running},
                 {"Parent",<0.2925.0>},
                 {"Logged events",[]}]},
          {data,[{"State",
                  #state{host = "172.100.239.2",port = 7000,
                         password = "******",database = <<"0">>,sentinel = undefined,
                         reconnect_sleep = no_reconnect,connect_timeout = 5000,
                         socket = #Port<0.80>,
                         parser_state = #pstate{state = undefined,
                                                continuation_data = undefined},
                         queue = {[],[]}}}]}]]}
```