### PR TITLE
fix: redis_client crashed when parsing an error redis response

### DIFF
--- a/src/eredis_client.erl
+++ b/src/eredis_client.erl
@@ -301,8 +301,7 @@ handle_response(Data, #state{parser_state = ParserState,
         %% continuation data and we will try calling parse again when
         %% we have more data
         {continue, NewParserState} ->
-            State#state{parser_state = NewParserState};
-        _ -> ok
+            State#state{parser_state = NewParserState}
     end.
 
 %% @doc: Sends a value to the first client in queue. Returns the new

--- a/src/eredis_parser.erl
+++ b/src/eredis_parser.erl
@@ -92,7 +92,7 @@ parse(#pstate{state = undefined} = State, NewData) ->
         _ ->
             %% TODO: Handle the case where we start parsing a new
             %% response, but cannot make any sense of it
-            {error, unknown_response}
+            {error, {unknown_response, NewData}, State}
     end;
 %% The following clauses all match on different continuation states
 
@@ -253,7 +253,7 @@ parse_simple(Buffer) ->
             {continue, {incomplete_simple, Buffer}};
         NewlinePos ->
             <<Value:NewlinePos/binary, ?NL, Rest/binary>> = buffer_to_binary(Buffer),
-            {ok, Value, Rest}
+            {ok, Value, trim_nl(Rest)}
     end.
 
 parse_simple({incomplete_simple, Buffer}, NewData0) ->
@@ -310,3 +310,6 @@ return_error(Result, State, StateName) ->
         Res ->
             Res
     end.
+
+trim_nl(Bin) ->
+    string:trim(Bin, leading, [?NL]).

--- a/test/eredis_parser_tests.erl
+++ b/test/eredis_parser_tests.erl
@@ -150,10 +150,7 @@ bulk_nil_with_extra_test() ->
 
 bulk_crap_test() ->
     B = <<"\r\n">>,
-    ?assertEqual({error, unknown_response}, parse(init(), B)).
-
-
-
+    ?assertEqual({error, {unknown_response, B}, init()}, parse(init(), B)).
 
 multibulk_test() ->
     %% [{1, 1}, {2, 2}, {3, 3}]
@@ -307,6 +304,10 @@ error_test() ->
     B = <<"-ERR wrong number of arguments for 'get' command\r\n">>,
     ?assertEqual({error, <<"ERR wrong number of arguments for 'get' command">>, init()},
                  parse(init(), B)).
+
+error_1_test() ->
+    B = <<"-MISCONF Redis is configured to save RDB snapshots, but it's currently unable to persist to disk. Commands that may modify the data set are disabled, because this instance is configured to report errors during writes if RDB snapshotting fails (stop-writes-on-bgsave-error option). Please check the Redis logs for details about the RDB error.\r\n\r\n">>,
+    ?assertEqual({error, string:trim(B, both, ["\r\n", $-]), init()}, parse(init(), B)).
 
 integer_test() ->
     B = <<":2\r\n">>,

--- a/test/eredis_sub_tests.erl
+++ b/test/eredis_sub_tests.erl
@@ -13,7 +13,7 @@ c() ->
     C.
 
 s() ->
-    Res = eredis_sub:start_link("127.0.0.1", 6379, ""),
+    Res = eredis_sub:start_link("127.0.0.1", 6379, "", 0),
     ?assertMatch({ok, _}, Res),
     {ok, C} = Res,
     C.
@@ -28,11 +28,6 @@ add_channels(Sub, Channels) ->
                       eredis_sub:ack_message(Sub)
               end
       end, Channels).
-
-
-
-
-
 
 pubsub_test() ->
     Pub = c(),
@@ -113,10 +108,9 @@ pubsub_connect_disconnect_messages_test() ->
     eredis_sub:stop(Sub).
 
 
-
 drop_queue_test() ->
     Pub = c(),
-    {ok, Sub} = eredis_sub:start_link("127.0.0.1", 6379, "", 100, 10, drop),
+    {ok, Sub} = eredis_sub:start_link("127.0.0.1", 6379, "", 0, 100, 10, drop),
     add_channels(Sub, [<<"foo">>]),
     ok = eredis_sub:controlling_process(Sub),
 
@@ -129,7 +123,7 @@ drop_queue_test() ->
 
 crash_queue_test() ->
     Pub = c(),
-    {ok, Sub} = eredis_sub:start_link("127.0.0.1", 6379, "", 100, 10, exit),
+    {ok, Sub} = eredis_sub:start_link("127.0.0.1", 6379, "", 0, 100, 10, exit),
     add_channels(Sub, [<<"foo">>]),
 
     true = unlink(Sub),


### PR DESCRIPTION
Parsing failed on receiving an error response:

```
<<"-MISCONF Redis is configured to save RDB snapshots, but it's currently unable to persist to disk. Commands that may modify the data set are disabled, because this instance is configured to report errors during writes if RDB snapshotting fails (stop-writes-on-bgsave-error option). Please check the Redis logs for details about the RDB error.\r\n\r\n">>
```