### PR TITLE
chore: support blessed format_status/1 callback

### DIFF
--- a/src/eredis.appup.src
+++ b/src/eredis.appup.src
@@ -1,5 +1,5 @@
 %% -*- mode: erlang -*-
-{"1.2.9",
+{"1.2.10",
   [
     {"1.1.0", [
       {add_module, eredis_secret},
@@ -55,6 +55,10 @@
       {load_module, eredis, brutal_purge, soft_purge, []},
       {load_module, eredis_client, brutal_purge, soft_purge, []},
       {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
+    ]},
+    {"1.2.9", [
+      {load_module, eredis_client, brutal_purge, soft_purge, []},
+      {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]}
   ],
   % {delete_module, eredis_secret}, %% this is intended to be missing in downgrade instructions,
@@ -105,6 +109,10 @@
     ]},
     {<<"1\\.2\\.[5-8]">>, [
       {load_module, eredis, brutal_purge, soft_purge, []},
+      {load_module, eredis_client, brutal_purge, soft_purge, []},
+      {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
+    ]},
+    {"1.2.9", [
       {load_module, eredis_client, brutal_purge, soft_purge, []},
       {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]}

--- a/src/eredis_client.erl
+++ b/src/eredis_client.erl
@@ -30,7 +30,7 @@
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
-         terminate/2, code_change/3, format_status/2]).
+         terminate/2, code_change/3, format_status/1, format_status/2]).
 
 -export([reconnect_loop/3]).
 
@@ -227,10 +227,14 @@ terminate(_Reason, State) ->
 code_change(_, State, _) ->
     {ok, State}.
 
-format_status(_Opt, [_PDict, #state{} = State]) ->
-    [{data, [{"State", State#state{password = "******"}}]}];
+format_status(Status = #{state := State}) ->
+    Status#{state => censor_state(State)}.
+
+%% TODO
+%% This is deprecated since OTP-25 in favor of `format_status/1`. Remove once
+%% OTP-25 becomes minimum supported OTP version.
 format_status(_Opt, [_PDict, State]) ->
-    [{data, [{"State", State}]}].
+    [{data, [{"State", censor_state(State)}]}].
 
 close(_Transport, undefined) -> ok;
 close(Transport, Socket) ->
@@ -581,3 +585,8 @@ l2b(B) -> B.
 
 get_password(#state{password = Password}) ->
     l2b(eredis_secret:unwrap(Password)).
+
+censor_state(#state{} = State) ->
+    State#state{password = "******"};
+censor_state(State) ->
+    State.

--- a/src/eredis_sub_client.erl
+++ b/src/eredis_sub_client.erl
@@ -18,7 +18,7 @@
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
-         terminate/2, code_change/3, format_status/2]).
+         terminate/2, code_change/3, format_status/1, format_status/2]).
 
 %%
 %% API
@@ -237,10 +237,14 @@ terminate(_Reason, State) ->
 code_change(_, State, _) ->
     {ok, State}.
 
-format_status(_Opt, [_PDict, #state{} = State]) ->
-    [{data, [{"State", State#state{password = "******"}}]}];
+format_status(Status = #{state := State}) ->
+    Status#{state => censor_state(State)}.
+
+%% TODO
+%% This is deprecated since OTP-25 in favor of `format_status/1`. Remove once
+%% OTP-25 becomes minimum supported OTP version.
 format_status(_Opt, [_PDict, State]) ->
-    [{data, [{"State", State}]}].
+    [{data, [{"State", censor_state(State)}]}].
 
 %%--------------------------------------------------------------------
 %%% Internal functions
@@ -451,3 +455,8 @@ l2b(B) -> B.
 
 get_password(#state{password = Password}) ->
     l2b(eredis_secret:unwrap(Password)).
+
+censor_state(#state{} = State) ->
+    State#state{password = "******"};
+censor_state(State) ->
+    State.

--- a/test/eredis_sub_tests.erl
+++ b/test/eredis_sub_tests.erl
@@ -179,6 +179,10 @@ dynamic_channels_test() ->
 
     ?assertEqual({ok, [<<"newchan">>]}, eredis_sub:channels(Sub)).
 
+censored_password_test() ->
+    Sub = s(),
+    ?assertMatch(#state{password = "******"}, get_state(Sub)).
+
 
 recv_all(Sub) ->
     recv_all(Sub, []).

--- a/test/eredis_tests.erl
+++ b/test/eredis_tests.erl
@@ -161,6 +161,12 @@ multibulk_test_() ->
 undefined_database_test() ->
     ?assertMatch({ok,_}, eredis:start_link("localhost", 6379, undefined)).
 
+censored_password_test() ->
+    {ok, Pid} = eredis:start_link("127.0.0.1", 6379, 0, _Password = ""),
+    {status, Pid, _, [_, _, _, _, Misc]} = sys:get_status(Pid),
+    [State] = [State || {data, [{"State", State} | _Rest]} <- Misc],
+    ?assertMatch([state, _Host, _Port, "******" | _], tuple_to_list(State)).
+
 tcp_closed_test() ->
     C = c(),
     tcp_closed_rig(C).


### PR DESCRIPTION
Also mention that `format_status/2` callback is deprecated since OTP-25.

---

[EMQX-8562](https://emqx.atlassian.net/browse/EMQX-8562)