### PR TITLE
Support redis sentinel password auth

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,23 +9,30 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        otp:
-          - 24.3
-          - 25.1
+        erlang:
+          - otp: "24"
+            rebar3: "3.20"
+          - otp: "25"
+            rebar3: "3.22"
+          - otp: "26"
+            rebar3: "3.22"
+          - otp: "27"
+            rebar3: "3.24"
+
     steps:
       - uses: actions/checkout@v3
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: ${{ matrix.otp }}
-          rebar3-version: 3
-      - uses: isbang/compose-action@v1.4.1
+          otp-version: ${{ matrix.erlang.otp }}
+          rebar3-version: ${{ matrix.erlang.rebar3 }}
+      - uses: hoverkraft-tech/compose-action@v2.0.2
       - name: eunit
         run: rebar3 eunit -v -c
       - name: common test
         run: rebar3 ct -v -c
       - name: cover report
         run: rebar3 cover -v
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: cover
+          name: cover-${{ matrix.erlang.otp }}-${{ matrix.erlang.rebar3 }}
           path: _build/test/cover

--- a/src/eredis.appup.src
+++ b/src/eredis.appup.src
@@ -79,7 +79,7 @@
       {load_module, eredis_sentinel_client, brutal_purge, soft_purge, []},
       {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]},
-    {<<"1.2.1[1-4]">>, [
+    {<<"1\\.2\\.1[1-4]">>, [
       {load_module, eredis, brutal_purge, soft_purge, [eredis_client]},
       {load_module, eredis_sentinel_client, brutal_purge, soft_purge, []},
       {load_module, eredis_client, brutal_purge, soft_purge, []},
@@ -170,7 +170,7 @@
       {load_module, eredis_sentinel_client, brutal_purge, soft_purge, []},
       {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]},
-    {<<"1.2.1[1-4]">>, [
+    {<<"1\\.2\\.1[1-4]">>, [
       {load_module, eredis, brutal_purge, soft_purge, [eredis_client]},
       {load_module, eredis_sentinel_client, brutal_purge, soft_purge, []},
       {load_module, eredis_client, brutal_purge, soft_purge, []},

--- a/src/eredis.appup.src
+++ b/src/eredis.appup.src
@@ -1,5 +1,5 @@
 %% -*- mode: erlang -*-
-{"1.2.15",
+{"1.2.17",
   [
     {"1.1.0", [
       {add_module, eredis_secret},
@@ -46,6 +46,7 @@
       {add_module, eredis_secret},
       {load_module,eredis_sub,brutal_purge,soft_purge,[]},
       {load_module, eredis, brutal_purge, soft_purge, []},
+      {load_module, eredis_sentinel_client, brutal_purge, soft_purge, []},
       {load_module, eredis_client, brutal_purge, soft_purge, []},
       {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]},
@@ -53,6 +54,7 @@
       {add_module, eredis_secret},
       {load_module,eredis_sub,brutal_purge,soft_purge,[]},
       {load_module, eredis, brutal_purge, soft_purge, []},
+      {load_module, eredis_sentinel_client, brutal_purge, soft_purge, []},
       {load_module, eredis_client, brutal_purge, soft_purge, []},
       {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]},
@@ -60,6 +62,7 @@
       {add_module, eredis_secret},
       {load_module,eredis_sub,brutal_purge,soft_purge,[]},
       {load_module, eredis, brutal_purge, soft_purge, []},
+      {load_module, eredis_sentinel_client, brutal_purge, soft_purge, []},
       {load_module, eredis_client, brutal_purge, soft_purge, []},
       {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]},
@@ -67,16 +70,30 @@
       {load_module,eredis_sub,brutal_purge,soft_purge,[]},
       {load_module, eredis_client, brutal_purge, soft_purge, []},
       {load_module, eredis, brutal_purge, soft_purge, [eredis_client]},
+      {load_module, eredis_sentinel_client, brutal_purge, soft_purge, []},
       {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]},
     {"1.2.10", [
       {load_module, eredis_client, brutal_purge, soft_purge, []},
       {load_module, eredis, brutal_purge, soft_purge, [eredis_client]},
+      {load_module, eredis_sentinel_client, brutal_purge, soft_purge, []},
       {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]},
     {<<"1.2.1[1-4]">>, [
+      {load_module, eredis, brutal_purge, soft_purge, [eredis_client]},
+      {load_module, eredis_sentinel_client, brutal_purge, soft_purge, []},
       {load_module, eredis_client, brutal_purge, soft_purge, []},
       {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
+    ]},
+    {"1.2.15", [
+      {load_module, eredis, brutal_purge, soft_purge, [eredis_client]},
+      {load_module, eredis_sentinel_client, brutal_purge, soft_purge, []},
+      {load_module, eredis_client, brutal_purge, soft_purge, []},
+      {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
+    ]},
+    {"1.2.16", [
+      {load_module, eredis, brutal_purge, soft_purge, [eredis_client]},
+      {load_module, eredis_sentinel_client, brutal_purge, soft_purge, []}
     ]}
   ],
   % {delete_module, eredis_secret}, %% this is intended to be missing in downgrade instructions,
@@ -122,18 +139,21 @@
     {"1.2.3", [
       {load_module,eredis_sub,brutal_purge,soft_purge,[]},
       {load_module, eredis, brutal_purge, soft_purge, []},
+      {load_module, eredis_sentinel_client, brutal_purge, soft_purge, []},
       {load_module, eredis_client, brutal_purge, soft_purge, []},
       {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]},
     {"1.2.4", [
       {load_module,eredis_sub,brutal_purge,soft_purge,[]},
       {load_module, eredis, brutal_purge, soft_purge, []},
+      {load_module, eredis_sentinel_client, brutal_purge, soft_purge, []},
       {load_module, eredis_client, brutal_purge, soft_purge, []},
       {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]},
     {<<"1\\.2\\.[5-8]">>, [
       {load_module,eredis_sub,brutal_purge,soft_purge,[]},
       {load_module, eredis, brutal_purge, soft_purge, []},
+      {load_module, eredis_sentinel_client, brutal_purge, soft_purge, []},
       {load_module, eredis_client, brutal_purge, soft_purge, []},
       {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]},
@@ -141,16 +161,30 @@
       {load_module,eredis_sub,brutal_purge,soft_purge,[]},
       {load_module, eredis_client, brutal_purge, soft_purge, []},
       {load_module, eredis, brutal_purge, soft_purge, [eredis_client]},
+      {load_module, eredis_sentinel_client, brutal_purge, soft_purge, []},
       {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]},
     {"1.2.10", [
       {load_module, eredis_client, brutal_purge, soft_purge, []},
       {load_module, eredis, brutal_purge, soft_purge, [eredis_client]},
+      {load_module, eredis_sentinel_client, brutal_purge, soft_purge, []},
       {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
     ]},
     {<<"1.2.1[1-4]">>, [
+      {load_module, eredis, brutal_purge, soft_purge, [eredis_client]},
+      {load_module, eredis_sentinel_client, brutal_purge, soft_purge, []},
       {load_module, eredis_client, brutal_purge, soft_purge, []},
       {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
+    ]},
+    {"1.2.15", [
+      {load_module, eredis, brutal_purge, soft_purge, [eredis_client]},
+      {load_module, eredis_sentinel_client, brutal_purge, soft_purge, []},
+      {load_module, eredis_client, brutal_purge, soft_purge, []},
+      {load_module, eredis_sub_client, brutal_purge, soft_purge, []}
+    ]},
+    {"1.2.16", [
+      {load_module, eredis, brutal_purge, soft_purge, [eredis_client]},
+      {load_module, eredis_sentinel_client, brutal_purge, soft_purge, []}
     ]}
   ]
 }.

--- a/src/eredis.erl
+++ b/src/eredis.erl
@@ -236,6 +236,20 @@ maybe_start_sentinel(Args) ->
             end;
         Sentinel ->
             Servers = proplists:get_value(servers, Args, []),
-            _ = eredis_sentinel:start_link(Servers, Options),
+            _ = eredis_sentinel:start_link(Servers, sentinel_options(Args, Options)),
             {"sentinel:" ++ Sentinel, 6379}
+    end.
+
+sentinel_options(Args, Options) ->
+    maybe_prepend_option(username, Args, maybe_prepend_option(password, Args, Options)).
+
+maybe_prepend_option(Key, Args, Options) ->
+    case proplists:is_defined(Key, Options) of
+        true ->
+            Options;
+        false ->
+            case proplists:get_value(Key, Args) of
+                undefined -> Options;
+                Value -> [{Key, Value} | Options]
+            end
     end.

--- a/src/eredis_sentinel_client.erl
+++ b/src/eredis_sentinel_client.erl
@@ -49,7 +49,7 @@ get_master_response({error, <<"IDONTKNOW", _Rest/binary >>}) ->
 start_link_maybe_auth(Host, Port, Opts) ->
     case start_link_without_auth(Host, Port, Opts) of
         {ok, Pid} ->
-            case eredis:q(Pid, ["PING"]) of
+            case ping(Pid) of
                 {ok, _} ->
                     {ok, Pid};
                 {error, Reason} ->
@@ -65,6 +65,15 @@ start_link_maybe_auth(Host, Port, Opts) ->
 
 start_link_without_auth(Host, Port, Opts) ->
     eredis:start_link(Host, Port, undefined, "", no_reconnect, 5000, Opts).
+
+ping(Pid) ->
+    try eredis:q(Pid, ["PING"]) of
+        Result -> Result
+    catch
+        exit:{timeout, _} -> {error, timeout};
+        exit:Reason -> {error, Reason};
+        Class:Reason -> {error, {Class, Reason}}
+    end.
 
 has_password(Opts) ->
     proplists:get_value(password, Opts, "") =/= "".

--- a/src/eredis_sentinel_client.erl
+++ b/src/eredis_sentinel_client.erl
@@ -76,7 +76,12 @@ ping(Pid) ->
     end.
 
 has_password(Opts) ->
-    proplists:get_value(password, Opts, "") =/= "".
+    case proplists:get_value(password, Opts, undefined) of
+        undefined -> false;
+        "" -> false;
+        <<>> -> false;
+        _ -> true
+    end.
 
 credentials(Opts) ->
     Password = proplists:get_value(password, Opts, ""),

--- a/src/eredis_sentinel_client.erl
+++ b/src/eredis_sentinel_client.erl
@@ -15,7 +15,10 @@ start_link(Host, Port) when is_list(Host), is_integer(Port) ->
     start_link(Host, Port, []).
 
 start_link(Host, Port, Opts) when is_list(Host), is_integer(Port), is_list(Opts) ->
-    eredis:start_link(Host, Port, undefined, "", no_reconnect, 5000, Opts).
+    case has_password(Opts) of
+        true -> start_link_maybe_auth(Host, Port, Opts);
+        false -> start_link_without_auth(Host, Port, Opts)
+    end.
 
 stop(Pid) when is_pid(Pid) ->
     catch eredis:stop(Pid).
@@ -42,3 +45,38 @@ get_master_response({ok, undefined}) ->
     {error, ?MASTER_UNKNOWN};
 get_master_response({error, <<"IDONTKNOW", _Rest/binary >>}) ->
     {error, ?MASTER_UNREACHABLE}.
+
+start_link_maybe_auth(Host, Port, Opts) ->
+    case start_link_without_auth(Host, Port, Opts) of
+        {ok, Pid} ->
+            case eredis:q(Pid, ["PING"]) of
+                {ok, _} ->
+                    {ok, Pid};
+                {error, Reason} ->
+                    stop(Pid),
+                    case auth_required(Reason) of
+                        true -> eredis:start_link(Host, Port, undefined, credentials(Opts), no_reconnect, 5000, Opts);
+                        false -> {error, #{type => connection_error, reason => Reason, host => Host, port => Port}}
+                    end
+            end;
+        Error ->
+            Error
+    end.
+
+start_link_without_auth(Host, Port, Opts) ->
+    eredis:start_link(Host, Port, undefined, "", no_reconnect, 5000, Opts).
+
+has_password(Opts) ->
+    proplists:get_value(password, Opts, "") =/= "".
+
+credentials(Opts) ->
+    Password = proplists:get_value(password, Opts, ""),
+    case proplists:get_value(username, Opts, undefined) of
+        undefined -> Password;
+        Username -> #{username => Username, password => Password}
+    end.
+
+auth_required(Reason) when is_binary(Reason) ->
+    binary:match(Reason, <<"NOAUTH">>) =/= nomatch;
+auth_required(_) ->
+    false.

--- a/test/eredis_SUITE.erl
+++ b/test/eredis_SUITE.erl
@@ -31,6 +31,8 @@ groups() ->
              pipeline_mixed_test,
              q_noreply_test,
              q_async_test,
+             sentinel_auth_test,
+             sentinel_auth_fallback_test,
              socket_closed_test],
     AuthGroups = [{group, username_password}, {group, password_only}],
     [
@@ -215,6 +217,22 @@ q_async_test(Config) ->
 undefined_database_test() ->
     ?assertMatch({ok,_}, eredis:start_link("localhost", 6379, undefined)).
 
+sentinel_auth_test(_Config) ->
+    {Port, Acceptor} = start_fake_sentinel(auth_required),
+    {ok, C} = eredis_sentinel_client:start_link("127.0.0.1", Port, [{password, "public"}]),
+    ?assertEqual({ok, {"127.0.0.1", 6379}}, eredis_sentinel_client:get_master(C, mymaster)),
+    eredis_sentinel_client:stop(C),
+    Acceptor ! stop,
+    ok.
+
+sentinel_auth_fallback_test(_Config) ->
+    {Port, Acceptor} = start_fake_sentinel(auth_disabled),
+    {ok, C} = eredis_sentinel_client:start_link("127.0.0.1", Port, [{password, "public"}]),
+    ?assertEqual({ok, {"127.0.0.1", 6379}}, eredis_sentinel_client:get_master(C, mymaster)),
+    eredis_sentinel_client:stop(C),
+    Acceptor ! stop,
+    ok.
+
 socket_closed_test(Config) ->
     C = c(Config),
     Header = case proplists:get_value(t, Config) of
@@ -256,3 +274,65 @@ gather_remote_queries([Pid | Rest], Acc) ->
         10000 ->
             error({gather_remote_queries, timeout})
     end.
+
+start_fake_sentinel(Mode) ->
+    Parent = self(),
+    {ok, Listen} = gen_tcp:listen(0, [binary, {active, false}, {packet, raw}, {ip, {127, 0, 0, 1}}]),
+    {ok, Port} = inet:port(Listen),
+    Acceptor = spawn_link(fun() -> fake_sentinel_accept(Parent, Listen, Mode) end),
+    {Port, Acceptor}.
+
+fake_sentinel_accept(Parent, Listen, Mode) ->
+    receive
+        stop ->
+            gen_tcp:close(Listen)
+    after 0 ->
+        case gen_tcp:accept(Listen, 100) of
+            {ok, Socket} ->
+                fake_sentinel_loop(Parent, Socket, Mode, Mode =:= auth_disabled),
+                fake_sentinel_accept(Parent, Listen, Mode);
+            {error, timeout} ->
+                fake_sentinel_accept(Parent, Listen, Mode)
+        end
+    end.
+
+fake_sentinel_loop(Parent, Socket, Mode, Authed) ->
+    receive
+        stop ->
+            gen_tcp:close(Socket)
+    after 0 ->
+        case gen_tcp:recv(Socket, 0, 5000) of
+            {ok, Data} ->
+                case parse_resp_command(Data) of
+                    [<<"PING">>] when Authed ->
+                        ok = gen_tcp:send(Socket, <<"+PONG\r\n">>),
+                        fake_sentinel_loop(Parent, Socket, Mode, Authed);
+                    [<<"AUTH">>, <<"public">>] when Mode =:= auth_required ->
+                        Parent ! sentinel_authed,
+                        ok = gen_tcp:send(Socket, <<"+OK\r\n">>),
+                        fake_sentinel_loop(Parent, Socket, Mode, true);
+                    [<<"AUTH">>, <<"public">>] ->
+                        ok = gen_tcp:send(Socket, <<"-ERR AUTH <password> called without any password configured for the default user.\r\n">>),
+                        gen_tcp:close(Socket);
+                    [<<"SENTINEL">>, <<"get-master-addr-by-name">>, <<"mymaster">>] when Authed ->
+                        ok = gen_tcp:send(Socket, <<"*2\r\n$9\r\n127.0.0.1\r\n$4\r\n6379\r\n">>),
+                        fake_sentinel_loop(Parent, Socket, Mode, Authed);
+                    _ ->
+                        ok = gen_tcp:send(Socket, <<"-NOAUTH Authentication required.\r\n">>),
+                        fake_sentinel_loop(Parent, Socket, Mode, Authed)
+                end;
+            {error, closed} ->
+                ok
+        end
+    end.
+
+parse_resp_command(Data) ->
+    Lines = binary:split(Data, <<"\r\n">>, [global]),
+    parse_resp_lines(tl(Lines), []).
+
+parse_resp_lines([], Acc) ->
+    lists:reverse(Acc);
+parse_resp_lines([<<"$", _/binary>>, Arg | Rest], Acc) ->
+    parse_resp_lines(Rest, [Arg | Acc]);
+parse_resp_lines([_ | Rest], Acc) ->
+    parse_resp_lines(Rest, Acc).

--- a/test/eredis_SUITE.erl
+++ b/test/eredis_SUITE.erl
@@ -20,6 +20,7 @@ all() ->
         {group, ssl},
         sentinel_auth_test,
         sentinel_auth_fallback_test,
+        sentinel_empty_binary_password_test,
         sentinel_ping_timeout_test,
         fake_sentinel_resp_framing_test
     ].
@@ -235,6 +236,14 @@ sentinel_auth_fallback_test(_Config) ->
     Acceptor ! stop,
     ok.
 
+sentinel_empty_binary_password_test(_Config) ->
+    {Port, Acceptor} = start_fake_sentinel(ping_forbidden),
+    {ok, C} = eredis_sentinel_client:start_link("127.0.0.1", Port, [{password, <<>>}]),
+    ?assertEqual({ok, {"127.0.0.1", 6379}}, eredis_sentinel_client:get_master(C, mymaster)),
+    eredis_sentinel_client:stop(C),
+    Acceptor ! stop,
+    ok.
+
 sentinel_ping_timeout_test(_Config) ->
     {Port, Acceptor} = start_fake_sentinel(ping_timeout),
     Result = (catch eredis_sentinel_client:start_link("127.0.0.1", Port, [{password, "public"}])),
@@ -316,12 +325,17 @@ fake_sentinel_accept(Parent, Listen, Mode) ->
     after 0 ->
         case gen_tcp:accept(Listen, 100) of
             {ok, Socket} ->
-                fake_sentinel_loop(Parent, Socket, Mode, Mode =:= auth_disabled, <<>>),
+                fake_sentinel_loop(Parent, Socket, Mode, initial_auth_state(Mode), <<>>),
                 fake_sentinel_accept(Parent, Listen, Mode);
             {error, timeout} ->
                 fake_sentinel_accept(Parent, Listen, Mode)
         end
     end.
+
+initial_auth_state(auth_required) ->
+    false;
+initial_auth_state(_) ->
+    true.
 
 fake_sentinel_loop(Parent, Socket, Mode, Authed, Buffer) ->
     receive
@@ -361,13 +375,15 @@ handle_fake_sentinel_commands(Parent, Socket, Mode, Authed, [Command | Rest]) ->
             close
     end.
 
+handle_fake_sentinel_command(_Parent, Socket, ping_forbidden, Authed, [<<"PING">>]) ->
+    ok = gen_tcp:send(Socket, <<"-ERR PING should not be sent.\r\n">>),
+    {continue, Authed};
+handle_fake_sentinel_command(_Parent, _Socket, ping_timeout, Authed, [<<"PING">>]) ->
+    {continue, Authed};
 handle_fake_sentinel_command(_Parent, Socket, _Mode, true, [<<"PING">>]) ->
     ok = gen_tcp:send(Socket, <<"+PONG\r\n">>),
     {continue, true};
-handle_fake_sentinel_command(_Parent, _Socket, ping_timeout, Authed, [<<"PING">>]) ->
-    {continue, Authed};
-handle_fake_sentinel_command(Parent, Socket, auth_required, _Authed, [<<"AUTH">>, <<"public">>]) ->
-    Parent ! sentinel_authed,
+handle_fake_sentinel_command(_Parent, Socket, auth_required, _Authed, [<<"AUTH">>, <<"public">>]) ->
     ok = gen_tcp:send(Socket, <<"+OK\r\n">>),
     {continue, true};
 handle_fake_sentinel_command(_Parent, Socket, _Mode, _Authed, [<<"AUTH">>, <<"public">>]) ->

--- a/test/eredis_SUITE.erl
+++ b/test/eredis_SUITE.erl
@@ -22,7 +22,8 @@ all() ->
         sentinel_auth_fallback_test,
         sentinel_empty_binary_password_test,
         sentinel_ping_timeout_test,
-        fake_sentinel_resp_framing_test
+        fake_sentinel_resp_framing_test,
+        fake_sentinel_stop_test
     ].
 
 groups() ->
@@ -269,6 +270,15 @@ fake_sentinel_resp_framing_test(_Config) ->
     Acceptor ! stop,
     ok.
 
+fake_sentinel_stop_test(_Config) ->
+    {Port, Acceptor} = start_fake_sentinel(auth_disabled),
+    Ref = erlang:monitor(process, Acceptor),
+    {ok, Socket} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}, {packet, raw}]),
+    Acceptor ! stop,
+    ?assertEqual(ok, wait_for_process_down(Ref, Acceptor, 1000)),
+    gen_tcp:close(Socket),
+    ok.
+
 socket_closed_test(Config) ->
     C = c(Config),
     Header = case proplists:get_value(t, Config) of
@@ -311,24 +321,34 @@ gather_remote_queries([Pid | Rest], Acc) ->
             error({gather_remote_queries, timeout})
     end.
 
+wait_for_process_down(Ref, Pid, Timeout) ->
+    receive
+        {'DOWN', Ref, process, Pid, _Reason} ->
+            ok
+    after Timeout ->
+        Pid ! stop,
+        error({process_still_alive, Pid})
+    end.
+
 start_fake_sentinel(Mode) ->
-    Parent = self(),
     {ok, Listen} = gen_tcp:listen(0, [binary, {active, false}, {packet, raw}, {ip, {127, 0, 0, 1}}]),
     {ok, Port} = inet:port(Listen),
-    Acceptor = spawn_link(fun() -> fake_sentinel_accept(Parent, Listen, Mode) end),
+    Acceptor = spawn_link(fun() -> fake_sentinel_accept(Listen, Mode) end),
     {Port, Acceptor}.
 
-fake_sentinel_accept(Parent, Listen, Mode) ->
+fake_sentinel_accept(Listen, Mode) ->
     receive
         stop ->
             gen_tcp:close(Listen)
     after 0 ->
         case gen_tcp:accept(Listen, 100) of
             {ok, Socket} ->
-                fake_sentinel_loop(Parent, Socket, Mode, initial_auth_state(Mode), <<>>),
-                fake_sentinel_accept(Parent, Listen, Mode);
+                case fake_sentinel_loop(Listen, Socket, Mode, initial_auth_state(Mode), <<>>) of
+                    stopped -> ok;
+                    ok -> fake_sentinel_accept(Listen, Mode)
+                end;
             {error, timeout} ->
-                fake_sentinel_accept(Parent, Listen, Mode)
+                fake_sentinel_accept(Listen, Mode)
         end
     end.
 
@@ -337,62 +357,64 @@ initial_auth_state(auth_required) ->
 initial_auth_state(_) ->
     true.
 
-fake_sentinel_loop(Parent, Socket, Mode, Authed, Buffer) ->
+fake_sentinel_loop(Listen, Socket, Mode, Authed, Buffer) ->
     receive
         stop ->
-            gen_tcp:close(Socket)
+            gen_tcp:close(Socket),
+            gen_tcp:close(Listen),
+            stopped
     after 0 ->
-        case gen_tcp:recv(Socket, 0, 5000) of
+        case gen_tcp:recv(Socket, 0, 100) of
             {ok, Data} ->
-                handle_fake_sentinel_data(Parent, Socket, Mode, Authed, <<Buffer/binary, Data/binary>>);
+                handle_fake_sentinel_data(Listen, Socket, Mode, Authed, <<Buffer/binary, Data/binary>>);
             {error, timeout} ->
-                fake_sentinel_loop(Parent, Socket, Mode, Authed, Buffer);
+                fake_sentinel_loop(Listen, Socket, Mode, Authed, Buffer);
             {error, closed} ->
                 ok
         end
     end.
 
-handle_fake_sentinel_data(Parent, Socket, Mode, Authed, Buffer) ->
+handle_fake_sentinel_data(Listen, Socket, Mode, Authed, Buffer) ->
     case parse_resp_commands(Buffer) of
         {ok, Commands, Rest} ->
-            case handle_fake_sentinel_commands(Parent, Socket, Mode, Authed, Commands) of
+            case handle_fake_sentinel_commands(Socket, Mode, Authed, Commands) of
                 {continue, Authed1} ->
-                    fake_sentinel_loop(Parent, Socket, Mode, Authed1, Rest);
+                    fake_sentinel_loop(Listen, Socket, Mode, Authed1, Rest);
                 close ->
                     gen_tcp:close(Socket)
             end;
         more ->
-            fake_sentinel_loop(Parent, Socket, Mode, Authed, Buffer)
+            fake_sentinel_loop(Listen, Socket, Mode, Authed, Buffer)
     end.
 
-handle_fake_sentinel_commands(_Parent, _Socket, _Mode, Authed, []) ->
+handle_fake_sentinel_commands(_Socket, _Mode, Authed, []) ->
     {continue, Authed};
-handle_fake_sentinel_commands(Parent, Socket, Mode, Authed, [Command | Rest]) ->
-    case handle_fake_sentinel_command(Parent, Socket, Mode, Authed, Command) of
+handle_fake_sentinel_commands(Socket, Mode, Authed, [Command | Rest]) ->
+    case handle_fake_sentinel_command(Socket, Mode, Authed, Command) of
         {continue, Authed1} ->
-            handle_fake_sentinel_commands(Parent, Socket, Mode, Authed1, Rest);
+            handle_fake_sentinel_commands(Socket, Mode, Authed1, Rest);
         close ->
             close
     end.
 
-handle_fake_sentinel_command(_Parent, Socket, ping_forbidden, Authed, [<<"PING">>]) ->
+handle_fake_sentinel_command(Socket, ping_forbidden, Authed, [<<"PING">>]) ->
     ok = gen_tcp:send(Socket, <<"-ERR PING should not be sent.\r\n">>),
     {continue, Authed};
-handle_fake_sentinel_command(_Parent, _Socket, ping_timeout, Authed, [<<"PING">>]) ->
+handle_fake_sentinel_command(_Socket, ping_timeout, Authed, [<<"PING">>]) ->
     {continue, Authed};
-handle_fake_sentinel_command(_Parent, Socket, _Mode, true, [<<"PING">>]) ->
+handle_fake_sentinel_command(Socket, _Mode, true, [<<"PING">>]) ->
     ok = gen_tcp:send(Socket, <<"+PONG\r\n">>),
     {continue, true};
-handle_fake_sentinel_command(_Parent, Socket, auth_required, _Authed, [<<"AUTH">>, <<"public">>]) ->
+handle_fake_sentinel_command(Socket, auth_required, _Authed, [<<"AUTH">>, <<"public">>]) ->
     ok = gen_tcp:send(Socket, <<"+OK\r\n">>),
     {continue, true};
-handle_fake_sentinel_command(_Parent, Socket, _Mode, _Authed, [<<"AUTH">>, <<"public">>]) ->
+handle_fake_sentinel_command(Socket, _Mode, _Authed, [<<"AUTH">>, <<"public">>]) ->
     ok = gen_tcp:send(Socket, <<"-ERR AUTH <password> called without any password configured for the default user.\r\n">>),
     close;
-handle_fake_sentinel_command(_Parent, Socket, _Mode, true, [<<"SENTINEL">>, <<"get-master-addr-by-name">>, <<"mymaster">>]) ->
+handle_fake_sentinel_command(Socket, _Mode, true, [<<"SENTINEL">>, <<"get-master-addr-by-name">>, <<"mymaster">>]) ->
     ok = gen_tcp:send(Socket, <<"*2\r\n$9\r\n127.0.0.1\r\n$4\r\n6379\r\n">>),
     {continue, true};
-handle_fake_sentinel_command(_Parent, Socket, _Mode, Authed, _Command) ->
+handle_fake_sentinel_command(Socket, _Mode, Authed, _Command) ->
     ok = gen_tcp:send(Socket, <<"-NOAUTH Authentication required.\r\n">>),
     {continue, Authed}.
 

--- a/test/eredis_SUITE.erl
+++ b/test/eredis_SUITE.erl
@@ -17,7 +17,11 @@
 all() ->
     [
         {group, tcp},
-        {group, ssl}
+        {group, ssl},
+        sentinel_auth_test,
+        sentinel_auth_fallback_test,
+        sentinel_ping_timeout_test,
+        fake_sentinel_resp_framing_test
     ].
 
 groups() ->
@@ -31,8 +35,6 @@ groups() ->
              pipeline_mixed_test,
              q_noreply_test,
              q_async_test,
-             sentinel_auth_test,
-             sentinel_auth_fallback_test,
              socket_closed_test],
     AuthGroups = [{group, username_password}, {group, password_only}],
     [
@@ -233,6 +235,31 @@ sentinel_auth_fallback_test(_Config) ->
     Acceptor ! stop,
     ok.
 
+sentinel_ping_timeout_test(_Config) ->
+    {Port, Acceptor} = start_fake_sentinel(ping_timeout),
+    Result = (catch eredis_sentinel_client:start_link("127.0.0.1", Port, [{password, "public"}])),
+    ?assertMatch({error, #{type := connection_error, reason := timeout}}, Result),
+    Acceptor ! stop,
+    ok.
+
+fake_sentinel_resp_framing_test(_Config) ->
+    {Port, Acceptor} = start_fake_sentinel(auth_required),
+    {ok, Socket} = gen_tcp:connect({127, 0, 0, 1}, Port, [binary, {active, false}, {packet, raw}]),
+    Ping = iolist_to_binary(eredis:create_multibulk(["PING"])),
+    {PingHead, PingTail} = split_binary(Ping, 3),
+    ok = gen_tcp:send(Socket, PingHead),
+    ?assertEqual({error, timeout}, gen_tcp:recv(Socket, 0, 50)),
+    ok = gen_tcp:send(Socket, PingTail),
+    ?assertEqual(<<"-NOAUTH Authentication required.\r\n">>, recv_until(Socket, <<"\r\n">>, 1000)),
+    Auth = iolist_to_binary(eredis:create_multibulk(["AUTH", "public"])),
+    GetMaster = iolist_to_binary(eredis:create_multibulk(["SENTINEL", "get-master-addr-by-name", "mymaster"])),
+    ok = gen_tcp:send(Socket, <<Auth/binary, GetMaster/binary>>),
+    ?assertEqual(<<"+OK\r\n*2\r\n$9\r\n127.0.0.1\r\n$4\r\n6379\r\n">>,
+                 recv_until(Socket, <<"6379\r\n">>, 1000)),
+    gen_tcp:close(Socket),
+    Acceptor ! stop,
+    ok.
+
 socket_closed_test(Config) ->
     C = c(Config),
     Header = case proplists:get_value(t, Config) of
@@ -289,50 +316,127 @@ fake_sentinel_accept(Parent, Listen, Mode) ->
     after 0 ->
         case gen_tcp:accept(Listen, 100) of
             {ok, Socket} ->
-                fake_sentinel_loop(Parent, Socket, Mode, Mode =:= auth_disabled),
+                fake_sentinel_loop(Parent, Socket, Mode, Mode =:= auth_disabled, <<>>),
                 fake_sentinel_accept(Parent, Listen, Mode);
             {error, timeout} ->
                 fake_sentinel_accept(Parent, Listen, Mode)
         end
     end.
 
-fake_sentinel_loop(Parent, Socket, Mode, Authed) ->
+fake_sentinel_loop(Parent, Socket, Mode, Authed, Buffer) ->
     receive
         stop ->
             gen_tcp:close(Socket)
     after 0 ->
         case gen_tcp:recv(Socket, 0, 5000) of
             {ok, Data} ->
-                case parse_resp_command(Data) of
-                    [<<"PING">>] when Authed ->
-                        ok = gen_tcp:send(Socket, <<"+PONG\r\n">>),
-                        fake_sentinel_loop(Parent, Socket, Mode, Authed);
-                    [<<"AUTH">>, <<"public">>] when Mode =:= auth_required ->
-                        Parent ! sentinel_authed,
-                        ok = gen_tcp:send(Socket, <<"+OK\r\n">>),
-                        fake_sentinel_loop(Parent, Socket, Mode, true);
-                    [<<"AUTH">>, <<"public">>] ->
-                        ok = gen_tcp:send(Socket, <<"-ERR AUTH <password> called without any password configured for the default user.\r\n">>),
-                        gen_tcp:close(Socket);
-                    [<<"SENTINEL">>, <<"get-master-addr-by-name">>, <<"mymaster">>] when Authed ->
-                        ok = gen_tcp:send(Socket, <<"*2\r\n$9\r\n127.0.0.1\r\n$4\r\n6379\r\n">>),
-                        fake_sentinel_loop(Parent, Socket, Mode, Authed);
-                    _ ->
-                        ok = gen_tcp:send(Socket, <<"-NOAUTH Authentication required.\r\n">>),
-                        fake_sentinel_loop(Parent, Socket, Mode, Authed)
-                end;
+                handle_fake_sentinel_data(Parent, Socket, Mode, Authed, <<Buffer/binary, Data/binary>>);
+            {error, timeout} ->
+                fake_sentinel_loop(Parent, Socket, Mode, Authed, Buffer);
             {error, closed} ->
                 ok
         end
     end.
 
-parse_resp_command(Data) ->
-    Lines = binary:split(Data, <<"\r\n">>, [global]),
-    parse_resp_lines(tl(Lines), []).
+handle_fake_sentinel_data(Parent, Socket, Mode, Authed, Buffer) ->
+    case parse_resp_commands(Buffer) of
+        {ok, Commands, Rest} ->
+            case handle_fake_sentinel_commands(Parent, Socket, Mode, Authed, Commands) of
+                {continue, Authed1} ->
+                    fake_sentinel_loop(Parent, Socket, Mode, Authed1, Rest);
+                close ->
+                    gen_tcp:close(Socket)
+            end;
+        more ->
+            fake_sentinel_loop(Parent, Socket, Mode, Authed, Buffer)
+    end.
 
-parse_resp_lines([], Acc) ->
-    lists:reverse(Acc);
-parse_resp_lines([<<"$", _/binary>>, Arg | Rest], Acc) ->
-    parse_resp_lines(Rest, [Arg | Acc]);
-parse_resp_lines([_ | Rest], Acc) ->
-    parse_resp_lines(Rest, Acc).
+handle_fake_sentinel_commands(_Parent, _Socket, _Mode, Authed, []) ->
+    {continue, Authed};
+handle_fake_sentinel_commands(Parent, Socket, Mode, Authed, [Command | Rest]) ->
+    case handle_fake_sentinel_command(Parent, Socket, Mode, Authed, Command) of
+        {continue, Authed1} ->
+            handle_fake_sentinel_commands(Parent, Socket, Mode, Authed1, Rest);
+        close ->
+            close
+    end.
+
+handle_fake_sentinel_command(_Parent, Socket, _Mode, true, [<<"PING">>]) ->
+    ok = gen_tcp:send(Socket, <<"+PONG\r\n">>),
+    {continue, true};
+handle_fake_sentinel_command(_Parent, _Socket, ping_timeout, Authed, [<<"PING">>]) ->
+    {continue, Authed};
+handle_fake_sentinel_command(Parent, Socket, auth_required, _Authed, [<<"AUTH">>, <<"public">>]) ->
+    Parent ! sentinel_authed,
+    ok = gen_tcp:send(Socket, <<"+OK\r\n">>),
+    {continue, true};
+handle_fake_sentinel_command(_Parent, Socket, _Mode, _Authed, [<<"AUTH">>, <<"public">>]) ->
+    ok = gen_tcp:send(Socket, <<"-ERR AUTH <password> called without any password configured for the default user.\r\n">>),
+    close;
+handle_fake_sentinel_command(_Parent, Socket, _Mode, true, [<<"SENTINEL">>, <<"get-master-addr-by-name">>, <<"mymaster">>]) ->
+    ok = gen_tcp:send(Socket, <<"*2\r\n$9\r\n127.0.0.1\r\n$4\r\n6379\r\n">>),
+    {continue, true};
+handle_fake_sentinel_command(_Parent, Socket, _Mode, Authed, _Command) ->
+    ok = gen_tcp:send(Socket, <<"-NOAUTH Authentication required.\r\n">>),
+    {continue, Authed}.
+
+parse_resp_commands(Data) ->
+    parse_resp_commands(Data, []).
+
+parse_resp_commands(<<>>, Acc) ->
+    {ok, lists:reverse(Acc), <<>>};
+parse_resp_commands(Data, Acc) ->
+    case parse_resp_command(Data) of
+        {ok, Command, Rest} ->
+            parse_resp_commands(Rest, [Command | Acc]);
+        more when Acc =:= [] ->
+            more;
+        more ->
+            {ok, lists:reverse(Acc), Data}
+    end.
+
+parse_resp_command(Data) ->
+    case split_resp_line(Data) of
+        {ok, <<"*", CountBin/binary>>, Rest} ->
+            parse_resp_args(Rest, binary_to_integer(CountBin), []);
+        more ->
+            more
+    end.
+
+parse_resp_args(Rest, 0, Acc) ->
+    {ok, lists:reverse(Acc), Rest};
+parse_resp_args(Data, Count, Acc) ->
+    case split_resp_line(Data) of
+        {ok, <<"$", SizeBin/binary>>, Rest} ->
+            Size = binary_to_integer(SizeBin),
+            case Rest of
+                <<Arg:Size/binary, "\r\n", Tail/binary>> ->
+                    parse_resp_args(Tail, Count - 1, [Arg | Acc]);
+                _ ->
+                    more
+            end;
+        more ->
+            more
+    end.
+
+split_resp_line(Data) ->
+    case binary:match(Data, <<"\r\n">>) of
+        {Pos, 2} ->
+            Line = binary:part(Data, 0, Pos),
+            Rest = binary:part(Data, Pos + 2, byte_size(Data) - Pos - 2),
+            {ok, Line, Rest};
+        nomatch ->
+            more
+    end.
+
+recv_until(Socket, Pattern, Timeout) ->
+    recv_until(Socket, Pattern, Timeout, <<>>).
+
+recv_until(Socket, Pattern, Timeout, Acc) ->
+    case binary:match(Acc, Pattern) of
+        nomatch ->
+            {ok, Data} = gen_tcp:recv(Socket, 0, Timeout),
+            recv_until(Socket, Pattern, Timeout, <<Acc/binary, Data/binary>>);
+        _ ->
+            Acc
+    end.


### PR DESCRIPTION
## Summary

Fix Redis Sentinel connections when Sentinel itself requires password authentication.

This branch is intentionally based on the `1.2.15` tag commit (`2301e7352cf02ec5146e64eca8a708c9e1ce3588`), which is the version referenced by `emqx/emqx-enterprise` `main-v4.4-enterprise` before the enterprise-side fix. The current PR head is `1ea6f006dfb2ab399bfb15909830404ed269d414`.

## Details

- Pass top-level Redis `password` and optional `username` into Sentinel options when no explicit Sentinel credentials are provided.
- Let `eredis_sentinel_client` first try unauthenticated `PING`; only reconnect with credentials when Sentinel replies `NOAUTH`.
- Preserve deployments where Redis master requires a password but Sentinel itself does not.
- Treat `undefined`, `""`, and `<<>>` Sentinel passwords as absent so empty binary passwords do not trigger the auth-probe path.
- Wrap the initial Sentinel `PING` so a call timeout becomes a normal `{error, timeout}` connection error instead of crashing the caller.
- Buffer and incrementally parse RESP multibulk frames in the fake Sentinel test helper so split/coalesced TCP packets are handled correctly.
- Make fake Sentinel `stop` deterministically terminate the acceptor/listener even when a client socket is active.
- Remove unused fake Sentinel helper parameters/messages.
- Prepare `src/eredis.appup.src` for the next release version, `1.2.17`; `src/eredis.app.src` still uses `{vsn, "git"}` as before.
- Escape appup version regex dots for `1.2.11` through `1.2.14` so the pattern does not match non-version strings such as `1x2x11`.
- Update the PR workflow to use `actions/upload-artifact@v4` with unique matrix artifact names.

## Validation

- GitHub Actions matrix passed: OTP/rebar3 `24/3.20`, `25/3.22`, `26/3.22`, `27/3.24`
- `git diff --check`
- `erl -noshell -eval 'case file:consult("src/eredis.appup.src") of {ok, [_]} -> halt(0); Other -> io:format("~p~n", [Other]), halt(1) end.'`
- Appup regex check: `1.2.11` and `1.2.14` match; `1.2.15` and `1x2x11` do not match.
- `rebar3 compile`
- `rebar3 eunit -v -c`, 89 tests passed after starting Redis compose services
- Targeted CT cases passed: `sentinel_auth_test`, `sentinel_auth_fallback_test`, `sentinel_empty_binary_password_test`, `sentinel_ping_timeout_test`, `fake_sentinel_resp_framing_test`, `fake_sentinel_stop_test`
- Manual Docker smoke test with real password-protected Redis Sentinel passed: unauthenticated Sentinel `PING` returned `NOAUTH`; authenticated Sentinel `PING` returned `PONG`; `eredis_sentinel_client:get_master/2` returned the real master; `eredis:start_link/1` via Sentinel successfully ran `SET`/`GET` on the master.
- Full local `rebar3 ct -v -c` on this intentionally `1.2.15`-based branch fails only in the SSL group under OTP 27 hostname verification; eredis `master` already contains the `1.2.16` test-side TLS fix, and the GitHub PR matrix runs against the PR merge ref and passes.
